### PR TITLE
Change livelihoods text, hide "no target" for o-i-p

### DIFF
--- a/data/DALRRD.json
+++ b/data/DALRRD.json
@@ -172,7 +172,7 @@
       "value_target": null
     },
     {
-      "name": "Livelihoods",
+      "name": "Livelihoods supported",
       "section_type": "livelihoods",
       "metrics": [
         {

--- a/data/DSAC.json
+++ b/data/DSAC.json
@@ -816,7 +816,7 @@
       "value_target": null
     },
     {
-      "name": "Livelihoods",
+      "name": "Livelihoods supported",
       "section_type": "livelihoods",
       "metrics": [
         {

--- a/data/DSD.json
+++ b/data/DSD.json
@@ -188,7 +188,7 @@
       "value_target": null
     },
     {
-      "name": "Livelihoods",
+      "name": "Livelihoods supported",
       "section_type": "livelihoods",
       "metrics": [
         {

--- a/data/all_data.json
+++ b/data/all_data.json
@@ -97,14 +97,14 @@
                     "value_target": 1900
                   },
                   {
-                    "key": "DCOGTA",
-                    "value": 0,
-                    "value_target": 25000
-                  },
-                  {
                     "key": "DSD",
                     "value": 0,
                     "value_target": 500
+                  },
+                  {
+                    "key": "DCOGTA",
+                    "value": 0,
+                    "value_target": 25000
                   }
                 ],
                 "data_missing": false
@@ -147,7 +147,7 @@
             "implementation_detail": null
           },
           {
-            "name": "Livelihoods",
+            "name": "Livelihoods supported",
             "metric_type": "livelihoods",
             "value": 64685,
             "dimensions": [
@@ -457,7 +457,7 @@
           "value_target": null
         },
         {
-          "name": "Livelihoods",
+          "name": "Livelihoods supported",
           "section_type": "livelihoods",
           "metrics": [
             {
@@ -4012,7 +4012,7 @@
           "value_target": null
         },
         {
-          "name": "Livelihoods",
+          "name": "Livelihoods supported",
           "section_type": "livelihoods",
           "metrics": [
             {
@@ -4467,7 +4467,7 @@
           "value_target": null
         },
         {
-          "name": "Livelihoods",
+          "name": "Livelihoods supported",
           "section_type": "livelihoods",
           "metrics": [
             {

--- a/python-src/presidential_employment.py
+++ b/python-src/presidential_employment.py
@@ -134,7 +134,7 @@ section_titles = {
     SectionEnum.targets.name: "Programme targets for this department",
     SectionEnum.job_opportunities.name: "Jobs created",
     SectionEnum.jobs_retain.name: "Jobs retained",
-    SectionEnum.livelihoods.name: "Livelihoods",
+    SectionEnum.livelihoods.name: "Livelihoods supported",
     SectionEnum.targets.name + "_overview": "Programme targets",
     SectionEnum.job_opportunities.name + "_overview": "Job opportunities",
     SectionEnum.jobs_retain.name + "_overview": "Jobs retained",

--- a/src/js/metric.js
+++ b/src/js/metric.js
@@ -47,7 +47,11 @@ export class Metric {
         if (this._value) {
           this._bottomText = `${metricType === "currency" ? 'SPEND' : 'ACHIEVED'}: ${this._formatter(this._value)}`;
         } else {
-          this._bottomText = "Target not available";
+          if (this._title === "Opportunities in process") {
+            this._bottomText == ""
+          } else {
+            this._bottomText = "Target not available";
+          }
         }
       }
 


### PR DESCRIPTION
* Change Livelihoods to Livelihoods supported throughout
* Remote "TARGET NOT AVAILABLE" from Opportunities in progress report