### PR TITLE
Compute provincial breakdown for overview page

### DIFF
--- a/data/all_data.json
+++ b/data/all_data.json
@@ -368,6 +368,86 @@
                   }
                 ],
                 "data_missing": false
+              },
+              {
+                "name": "by province",
+                "viz": "bar",
+                "lookup": "province",
+                "values": [
+                  {
+                    "key": "EC",
+                    "value": [
+                      63406,
+                      45594
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "FS",
+                    "value": [
+                      22258,
+                      17467
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "GP",
+                    "value": [
+                      52669,
+                      55169
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "KZN",
+                    "value": [
+                      87614,
+                      72609
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "LP",
+                    "value": [
+                      55263,
+                      39786
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "MP",
+                    "value": [
+                      30043,
+                      24855
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NC",
+                    "value": [
+                      9820,
+                      6790
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NW",
+                    "value": [
+                      28702,
+                      19485
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "WC",
+                    "value": [
+                      27609,
+                      21994
+                    ],
+                    "value_target": null
+                  }
+                ],
+                "data_missing": false
               }
             ],
             "value_target": {
@@ -539,6 +619,86 @@
                   }
                 ],
                 "data_missing": false
+              },
+              {
+                "name": "by province",
+                "viz": "bar",
+                "lookup": "province",
+                "values": [
+                  {
+                    "key": "EC",
+                    "value": [
+                      25080,
+                      710
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "FS",
+                    "value": [
+                      7377,
+                      1
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "GP",
+                    "value": [
+                      21609,
+                      748
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "KZN",
+                    "value": [
+                      44694,
+                      4464
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "LP",
+                    "value": [
+                      21957,
+                      867
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "MP",
+                    "value": [
+                      18731,
+                      628
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NC",
+                    "value": [
+                      5284,
+                      508
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NW",
+                    "value": [
+                      13953,
+                      19
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "WC",
+                    "value": [
+                      6255,
+                      3
+                    ],
+                    "value_target": null
+                  }
+                ],
+                "data_missing": false
               }
             ],
             "value_target": {
@@ -697,6 +857,86 @@
                   {
                     "key": "202204",
                     "value": 40399,
+                    "value_target": null
+                  }
+                ],
+                "data_missing": false
+              },
+              {
+                "name": "by province",
+                "viz": "bar",
+                "lookup": "province",
+                "values": [
+                  {
+                    "key": "EC",
+                    "value": [
+                      5504,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "FS",
+                    "value": [
+                      1680,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "GP",
+                    "value": [
+                      6477,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "KZN",
+                    "value": [
+                      4292,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "LP",
+                    "value": [
+                      2120,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "MP",
+                    "value": [
+                      1106,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NC",
+                    "value": [
+                      4359,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "NW",
+                    "value": [
+                      2461,
+                      0
+                    ],
+                    "value_target": null
+                  },
+                  {
+                    "key": "WC",
+                    "value": [
+                      7310,
+                      0
+                    ],
                     "value_target": null
                   }
                 ],

--- a/notebooks/.ipynb_checkpoints/p-e_to_json-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/p-e_to_json-checkpoint.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
     "\n",
     "final_phase_1_excel = 'Phase 1 Dashboard input_PES targets and opportunities per month 09022022 Updated with Implementation 2.xlsx'\n",
     "\n",
-    "phase2_excel = 'April dashboard_2.xlsx'"
+    "phase2_excel = 'April dashboard_3_working.xlsx'"
    ]
   },
   {
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,25 +96,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "# dump metric titles (defined in python_src/presidential_employment.py) into metric_title.json\n",
     "json.dump(metric_titles, open(output_dir + \"/metric_titles.json\", \"w\"), indent=2)"
    ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -131,6 +119,8 @@
     " targets_df,\n",
     " trends_df,\n",
     " provincial_df,\n",
+    " cities_df,\n",
+    " universities_df,\n",
     " demographic_df,\n",
     " achievement_totals_df) = load_sheets(final_phase_1_excel, phase2_excel)"
    ]
@@ -714,8 +704,15 @@
     "all_data_departments = compute_all_data_departments(phase1_departments, phase2_departments, \n",
     "                                                    implementation_status_df, demographic_df, description_df,\n",
     "                                                    targets_df, trends_df, department_names, provincial_df,\n",
-    "                                                    leads, paragraphs)"
+    "                                                    cities_df, universities_df, leads, paragraphs)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -741,6 +738,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -749,13 +753,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'job_opportunities': {'EC': [63406, 45594], 'FS': [22258, 17467], 'GP': [52669, 55169], 'KZN': [87614, 72609], 'LP': [55263, 39786], 'NW': [28702, 19485], 'NC': [9820, 6790], 'WC': [27609, 21994], 'MP': [30043, 24855]}, 'livelihoods': {'EC': [25080, 710], 'FS': [7377, 1], 'GP': [21609, 748], 'KZN': [44694, 4464], 'LP': [21957, 867], 'NW': [13953, 19], 'NC': [5284, 508], 'WC': [6255, 3], 'MP': [18731, 628]}, 'jobs_retain': {'EC': [5504, 0], 'FS': [1680, 0], 'GP': [6477, 0], 'KZN': [4292, 0], 'LP': [2120, 0], 'NW': [2461, 0], 'NC': [4359, 0], 'WC': [7310, 0], 'MP': [1106, 0]}}\n"
+     ]
+    }
+   ],
    "source": [
     "(programmes_by_type,\n",
     " programmes_by_type_summarised,\n",
-    " achievements_by_type_by_month) = compute_programmes_by_type(all_data_departments, opportunity_achievements_df, opportunity_targets_df)"
+    " achievements_by_type_by_month,\n",
+    " provincial_breakdown) = compute_programmes_by_type(all_data_departments, opportunity_achievements_df, opportunity_targets_df)"
    ]
   },
   {
@@ -767,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,7 +882,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(breakdown_metrics, current_targets, current_achievements) = compute_overview_breakdown(programmes_by_type_summarised, achievements_by_type_by_month)\n",
+    "(breakdown_metrics, current_targets, current_achievements) = compute_overview_breakdown(programmes_by_type_summarised,\n",
+    "                                                                                        achievements_by_type_by_month,\n",
+    "                                                                                        provincial_breakdown)\n",
     "\n",
     "overview_metrics = compute_overview_metrics(total_female, total_beneficiaries, total_unknown_gender,\n",
     "                             opportunity_targets_df, programmes_by_type,\n",
@@ -1018,9 +1033,6 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "53fea97f8ee2896832459e85fe27e7ff11488111fd4d8eb8a49266b607f05c43"
-  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
@@ -1036,7 +1048,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "65b6769f767221e460d731dd72a0a5b92afdf85c55a81593fd9a9d9b40f34780"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/p-e_to_json.ipynb
+++ b/notebooks/p-e_to_json.ipynb
@@ -691,12 +691,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "M/F PERC PROBLEM: Sports, Arts and Culture Job retention in cultural and creative institutions - National Film and Video Foundation 0 0.636 0.36 0.996\n",
       "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Vegetables and Fruits 1 0.09 0.35 0.43999999999999995\n",
       "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Maize/soya/sugar/other production 1 0.031 0.104 0.135\n",
       "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Poultry: Layers and Boilers 1 0.058 0.161 0.219\n",
       "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Small livestock 1 0.053 0.077 0.13\n",
-      "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Large livestock 1 0.033 0.043 0.076\n",
-      "M/F PERC PROBLEM: Sports, Arts and Culture Job retention in cultural and creative institutions - National Film and Video Foundation 0 0.636 0.36 0.996\n"
+      "M/F PERC PROBLEM: Agriculture, Land Reform and Rural Development Large livestock 1 0.033 0.043 0.076\n"
      ]
     }
    ],
@@ -738,6 +738,13 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -746,13 +753,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'job_opportunities': {'EC': [63406, 45594], 'FS': [22258, 17467], 'GP': [52669, 55169], 'KZN': [87614, 72609], 'LP': [55263, 39786], 'NW': [28702, 19485], 'NC': [9820, 6790], 'WC': [27609, 21994], 'MP': [30043, 24855]}, 'livelihoods': {'EC': [25080, 710], 'FS': [7377, 1], 'GP': [21609, 748], 'KZN': [44694, 4464], 'LP': [21957, 867], 'NW': [13953, 19], 'NC': [5284, 508], 'WC': [6255, 3], 'MP': [18731, 628]}, 'jobs_retain': {'EC': [5504, 0], 'FS': [1680, 0], 'GP': [6477, 0], 'KZN': [4292, 0], 'LP': [2120, 0], 'NW': [2461, 0], 'NC': [4359, 0], 'WC': [7310, 0], 'MP': [1106, 0]}}\n"
+     ]
+    }
+   ],
    "source": [
     "(programmes_by_type,\n",
     " programmes_by_type_summarised,\n",
-    " achievements_by_type_by_month) = compute_programmes_by_type(all_data_departments, opportunity_achievements_df, opportunity_targets_df)"
+    " achievements_by_type_by_month,\n",
+    " provincial_breakdown) = compute_programmes_by_type(all_data_departments, opportunity_achievements_df, opportunity_targets_df)"
    ]
   },
   {
@@ -764,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,11 +878,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "(breakdown_metrics, current_targets, current_achievements) = compute_overview_breakdown(programmes_by_type_summarised, achievements_by_type_by_month)\n",
+    "(breakdown_metrics, current_targets, current_achievements) = compute_overview_breakdown(programmes_by_type_summarised,\n",
+    "                                                                                        achievements_by_type_by_month,\n",
+    "                                                                                        provincial_breakdown)\n",
     "\n",
     "overview_metrics = compute_overview_metrics(total_female, total_beneficiaries, total_unknown_gender,\n",
     "                             opportunity_targets_df, programmes_by_type,\n",
@@ -882,7 +900,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -903,7 +921,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -922,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -971,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,7 +1017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1016,7 +1034,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.4 ('altair')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
This computes the provincial breakdown for the overview page as MultiMetrics, i.e. key -> multiple value, broken down by opportunity type.